### PR TITLE
singularization rule for personas

### DIFF
--- a/inflect.go
+++ b/inflect.go
@@ -183,6 +183,7 @@ func newBoilRuleset() *inflect.Ruleset {
 	rs.AddSingularExact("quizzes", "quiz", true)
 	rs.AddSingular("databases", "database")
 	rs.AddSingular("menus", "menu")
+	rs.AddSingular("personas", "persona")
 	rs.AddIrregular("person", "people")
 	rs.AddIrregular("man", "men")
 	rs.AddIrregular("child", "children")

--- a/strmangle_test.go
+++ b/strmangle_test.go
@@ -145,6 +145,7 @@ func TestSingular(t *testing.T) {
 		{"areas", "area"},
 		{"hello_there_people", "hello_there_person"},
 		{"schemas", "schema"},
+		{"personas", "persona"},
 	}
 
 	for i, test := range tests {
@@ -167,6 +168,7 @@ func TestPlural(t *testing.T) {
 		{"area", "areas"},
 		{"hello_there_person", "hello_there_people"},
 		{"schema", "schemas"},
+		{"persona", "personas"},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Adds a singularization rule for personas -> persona. 

sqlboiler (v4.5.0) otherwise produces code that results in build errors, e.g.

```
CREATE TABLE personas (
    id uuid NOT NULL,
    name text NOT NULL,
    created_at timestamptz NOT NULL,
    updated_at timestamptz NOT NULL,
    CONSTRAINT personas_pkey PRIMARY KEY (id)
);
```

results in errors in the generated model, as it does not correctly singularize the struct name:  

```
Personas redeclared in this block (see details)compilerDuplicateDecl
personas.go(176, 6): Personas redeclared in this block
personas.go(25, 6): other declaration of Personas (this error)
```

```
type Personas struct {
[...]
func Personas(mods ...qm.QueryMod) personasQuery {
```

This can be mitigated with an alias configuration for that table, however it seems more reasonable to fix this directly in `strmangle`, analogous to previous issues, e.g. https://github.com/volatiletech/sqlboiler/issues/653