### PR TITLE
Add plural acronym test

### DIFF
--- a/strmangle_test.go
+++ b/strmangle_test.go
@@ -197,6 +197,7 @@ func TestTitleCase(t *testing.T) {
 		{"ssn", "SSN"},
 		{"tz", "TZ"},
 		{"thing_guid", "ThingGUID"},
+		{"thing_guids", "ThingGuids"},
 		{"guid_thing", "GUIDThing"},
 		{"thing_guid_thing", "ThingGUIDThing"},
 		{"id", "ID"},


### PR DESCRIPTION
This test shows potentially incorrect case conversion for an acronym when it's in plural form:
`"thing_guid" -> "ThingGUID"`
however
`"thing_guids" -> "ThingGuids"`
