### PR TITLE
sets SortByKeys bug fix

### DIFF
--- a/sets.go
+++ b/sets.go
@@ -68,7 +68,11 @@ func SetMerge(a []string, b []string) []string {
 
 // SortByKeys returns a new ordered slice based on the keys ordering
 func SortByKeys(keys []string, strs []string) []string {
-	c := make([]string, len(strs))
+	resultLen := len(strs)
+	if len(keys) < len(strs) {
+		resultLen = len(keys)
+	}
+	c := make([]string, resultLen)
 
 	index := 0
 Outer:

--- a/sets_test.go
+++ b/sets_test.go
@@ -121,6 +121,11 @@ func TestSortByKeys(t *testing.T) {
 			[]string{"stuff", "thing"},
 			[]string{"thing", "stuff"},
 		},
+		{
+			[]string{"stuff"},
+			[]string{"stuff", "thing"},
+			[]string{"stuff"},
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
This handles the case when the input slice of keys is smaller than the input string slice to sort.

The bug is that the resulting slice has extra empty strings since we're allocating a return string slice the size of the slice to sort and we don't want empty strings in the sorted slice. This just allocates the return slice to sort to the smaller length of keys or sliceToSort.