### PR TITLE
Add SetIntersect() method

### DIFF
--- a/sets.go
+++ b/sets.go
@@ -66,6 +66,22 @@ func SetMerge(a []string, b []string) []string {
 	return merged
 }
 
+// SetIntersect will return all elements present in both a and b
+func SetIntersect(a []string, b []string) []string {
+	intersection := make([]string, 0)
+
+	for _, aVal := range a {
+		for _, bVal := range b {
+			if aVal == bVal {
+				intersection = append(intersection, aVal)
+				break
+			}
+		}
+	}
+
+	return intersection
+}
+
 // SortByKeys returns a new ordered slice based on the keys ordering
 func SortByKeys(keys []string, strs []string) []string {
 	resultLen := len(strs)

--- a/sets_test.go
+++ b/sets_test.go
@@ -98,6 +98,39 @@ func TestSetMerge(t *testing.T) {
 	}
 }
 
+func TestSetIntersect(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		A []string
+		B []string
+		C []string
+	}{
+		{
+			[]string{"a", "b", "c"},
+			[]string{"a", "b", "c"},
+			[]string{"a", "b", "c"},
+		},
+		{
+			[]string{"a", "b", "c"},
+			[]string{"b", "c", "d"},
+			[]string{"b", "c"},
+		},
+		{
+			[]string{"a", "b", "c"},
+			[]string{"d", "e", "f"},
+			[]string{},
+		},
+	}
+
+	for i, test := range tests {
+		intersection := SetIntersect(test.A, test.B)
+		if !reflect.DeepEqual(test.C, intersection) {
+			t.Errorf("[%d] mismatch:\nWant: %#v\nGot: %#v", i, test.C, intersection)
+		}
+	}
+}
+
 func TestSortByKeys(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This PR adds the `SetIntersect()` method which calculates all elements present in both A and B. Required for https://github.com/volatiletech/sqlboiler/pull/1306