### PR TITLE
Add WhereInClause function

### DIFF
--- a/strmangle.go
+++ b/strmangle.go
@@ -579,6 +579,8 @@ func WhereInClause(lq, rq string, start int, cols []string, count int) string {
 	buf := GetBuffer()
 	defer PutBuffer(buf)
 
+	// Start is used as the dialect switch for $ or ?
+	// Because Placeholders will not accept 0 as a start index, set it to 1 and set useIndexPlaceholders appropriately
 	useIndexPlaceholders := true
 	if start == 0 {
 		start = 1

--- a/strmangle.go
+++ b/strmangle.go
@@ -573,6 +573,31 @@ func WhereClause(lq, rq string, start int, cols []string) string {
 	return buf.String()
 }
 
+// WhereInClause returns the where clause using start as the $ flag index
+// For example, if start was 2 output would be: "col IN ($2,$3)"
+func WhereInClause(lq, rq string, start int, cols []string, count int) string {
+	buf := GetBuffer()
+	defer PutBuffer(buf)
+
+	useIndexPlaceholders := true
+	if start == 0 {
+		start = 1
+		useIndexPlaceholders = false
+	}
+
+	for i, c := range cols {
+		buf.WriteString(fmt.Sprintf(`%s%s%s IN (`, lq, c, rq))
+		buf.WriteString(Placeholders(useIndexPlaceholders, count, start+i*count, 1))
+		buf.WriteByte(')')
+
+		if i < len(cols)-1 {
+			buf.WriteString(" AND ")
+		}
+	}
+
+	return buf.String()
+}
+
 // WhereClauseRepeated returns the where clause repeated with OR clause using start as the $ flag index
 // For example, if start was 2 output would be: "(colthing=$2 AND colstuff=$3) OR (colthing=$4 AND colstuff=$5)"
 func WhereClauseRepeated(lq, rq string, start int, cols []string, count int) string {

--- a/strmangle_test.go
+++ b/strmangle_test.go
@@ -349,6 +349,46 @@ func TestSetParamNames(t *testing.T) {
 	}
 }
 
+func TestWhereInClause(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		lq       string
+		rq       string
+		start    int
+		cols     []string
+		count    int
+		expected string
+	}{
+		{
+			name:     "Test with indexed placeholders",
+			lq:       `"`,
+			rq:       `"`,
+			start:    1,
+			cols:     []string{"col1", "col2"},
+			count:    2,
+			expected: `"col1" IN ($1,$2) AND "col2" IN ($3,$4)`,
+		},
+		{
+			name:     "Test with question mark placeholders",
+			lq:       `"`,
+			rq:       `"`,
+			start:    0,
+			cols:     []string{"col1", "col2"},
+			count:    2,
+			expected: `"col1" IN (?,?) AND "col2" IN (?,?)`,
+		},
+	}
+
+	for _, tt := range tests {
+		result := WhereInClause(tt.lq, tt.rq, tt.start, tt.cols, tt.count)
+		if result != tt.expected {
+			t.Errorf("WhereInClause() = %v, want %v", result, tt.expected)
+		}
+	}
+}
+
 func TestWhereClause(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
In postgres, a WHERE OR statement will take a considerable amount of time to process a query containing many args. Up to 15 minutes in our tests for 15k db entities. Most of this came from the query optimisation stage, and after that stage the db chose to search the table sequentially which is very slow. 

Using a WHERE IN statement, foreign key tables are joined, resulting in a query execution time of ~90ms for 15k entities.

More information about this speed increase can be found here: https://stackoverflow.com/questions/68484681/why-in-is-so-much-faster-than-in-sql-select