### PR TITLE
Support enum values with slash

### DIFF
--- a/strmangle.go
+++ b/strmangle.go
@@ -723,7 +723,8 @@ func ParseEnumVals(s string) []string {
 
 	startIndex := strings.IndexByte(s, '(')
 	s = s[startIndex+2 : len(s)-2]
-	return strings.Split(s, "','")
+	sanitized := strings.ReplaceAll(s, "/", "_")
+	return strings.Split(sanitized, "','")
 }
 
 // ParseEnumName returns the name portion of an enum if it exists

--- a/strmangle_test.go
+++ b/strmangle_test.go
@@ -578,6 +578,7 @@ func TestParseEnum(t *testing.T) {
 		{"enum.wor_king('one','two')", "wor_king", []string{"one", "two"}},
 		{"enum('with space','two')", "", []string{"with space", "two"}},
 		{"enum('WithCapitalLetters','WITH_CAPS_AND_UNDERSCORES')", "", []string{"WithCapitalLetters", "WITH_CAPS_AND_UNDERSCORES"}},
+		{"enum('/StartSlash','Slash/Between','SlashAtTheEnd/')", "", []string{"_StartSlash", "Slash_Between", "SlashAtTheEnd_"}},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Slash cannot be part of Golang const/variable name. Use underscore instead.

Fixes https://github.com/volatiletech/sqlboiler/issues/1253