### PR TITLE
Fix CamelCase

### DIFF
--- a/strmangle_test.go
+++ b/strmangle_test.go
@@ -185,6 +185,8 @@ func TestTitleCase(t *testing.T) {
 	}{
 		{"hello_there", "HelloThere"},
 		{"", ""},
+		{"418im_a_teapot", "418imATeapot"},
+		{"Slash/Test", "SlashTest"},
 		{"____a____a___", "AA"},
 		{"_a_a_", "AA"},
 		{"fun_id", "FunID"},
@@ -228,6 +230,9 @@ func TestCamelCase(t *testing.T) {
 		Out string
 	}{
 		{"hello_there_sunny", "helloThereSunny"},
+		{"418im_a_teapot", "418imATeapot"},
+		{"418_im_a_teapot", "418ImATeapot"},
+		{"Slash/Test", "slashTest"},
 		{"", ""},
 		{"a_", "a"},
 		{"aaa_", "aaa"},


### PR DESCRIPTION
`CamelCase` is used for e.g. L- and R-identifier generation in sqlboiler.

Example table
```sql
CREATE TABLE IF NOT EXISTS `Slash/Test` (
    id INT UNSIGNED NOT NULL AUTO_INCREMENT,

    `my_en/um` ENUM('test/1', '/test2', 'test3'),

    PRIMARY KEY (id)
);
```

Current output:
```
Error: unable to generate output: failed to format template

  22 )
  23 
  24 // SlashTest is an object representing the database table.
  25 type SlashTest struct {ID uint`csv:"id" hash:"id" boil:"id" json:"id" toml:"id" yaml:"id"`
  26 
>>>>    R *slash/TestR `csv:"-" hash:"-" boil:"-" json:"-" toml:"-" yaml:"-"`
  28    L slash/TestL `csv:"-" hash:"-" boil:"-" json:"-" toml:"-" yaml:"-"`
  29    }
  30 
  31 var SlashTestColumns = struct {
  32    ID string

: 27:10: expected ';', found '/' (and 10 more errors)
```